### PR TITLE
remove swift from build script (no script yet)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -549,23 +549,6 @@ BUILD-START "Shell" "johncena.sh"
 BUILD-END
 
 # -------------------------------------
-# Swift
-BUILD-START "Swift" "johncena.swift"
-	case "$(BUILD-FIND swift)" in
-		swift)
-			if INTERPRETED-COPY; then
-				BUILT true
-			else
-				INTERPRETED-WRAP swift "${OBJ}/${SRC_FILENAME}" '{$@}' > "${OUT_FILE}"
-				cp "${SRC_FILE}" "${OBJ}/${SRC_FILENAME}"
-				chmod +x "${OUT_FILE}"
-				BUILT TRUE
-			fi
-			;;
-	esac
-BUILD-END
-
-# -------------------------------------
 # Vala
 BUILD-START "Vala" "johncena.vala"
 	case "$(BUILD-FIND valac)" in


### PR DESCRIPTION
There doesn't seem to be a swift implementation, so the build script reports errors when attempting to install one. This PR removes the calls to install `johncena.swift`.